### PR TITLE
Make sure the Date transform extends the Ember Data version

### DIFF
--- a/addon/transforms/date.js
+++ b/addon/transforms/date.js
@@ -1,6 +1,6 @@
-import Transform from '@ember-data/serializer/transform';
+import { DateTransform as BaseDateTransform } from '@ember-data/serializer/-private';
 
-export default class DateTransform extends Transform {
+export default class DateTransform extends BaseDateTransform {
   serialize(date) {
     if (date instanceof Date) {
       return date.toISOString().substring(0, 10); // only keep 'YYYY-MM-DD' portion of the string

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.1",
     "ember-cli-update": "^1.0.0",
-    "ember-data": "^3.12.0",
+    "ember-data": "~3.26.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.2",

--- a/tests/unit/transforms/date-test.js
+++ b/tests/unit/transforms/date-test.js
@@ -4,9 +4,27 @@ import { setupTest } from 'ember-qunit';
 module('transform:date', 'Unit | Transform | date', function (hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
-  test('it exists', function (assert) {
-    let transform = this.owner.lookup('transform:date');
-    assert.ok(transform);
+  test('it deserializes date strings properly', function (assert) {
+    let transform = this.owner.lookup(
+      'transform:ember-mu-transform-helpers@date'
+    );
+
+    let deserialized = transform.deserialize('2021-12-21');
+
+    assert.ok(deserialized instanceof Date);
+    assert.equal(deserialized.getDate(), 21);
+    assert.equal(deserialized.getMonth(), 11);
+    assert.equal(deserialized.getFullYear(), 2021);
+  });
+
+  test('it serializes dates to ISO 8601 format without time information', function (assert) {
+    let transform = this.owner.lookup(
+      'transform:ember-mu-transform-helpers@date'
+    );
+
+    let date = new Date('2020-05-18');
+    let serialized = transform.serialize(date);
+
+    assert.equal(serialized, '2020-05-18');
   });
 });


### PR DESCRIPTION
Added some basic tests while I was at it. For some reason looking up `transform:date` resolves to the Ember Data version in the unit test.. So I used the namespaced version instead. I'm not sure why it happens though, since it works in apps.