### PR TITLE
Use the current timezone data when serializing dates

### DIFF
--- a/addon/transforms/date.js
+++ b/addon/transforms/date.js
@@ -3,9 +3,15 @@ import { DateTransform as BaseDateTransform } from '@ember-data/serializer/-priv
 export default class DateTransform extends BaseDateTransform {
   serialize(date) {
     if (date instanceof Date) {
-      return date.toISOString().substring(0, 10); // only keep 'YYYY-MM-DD' portion of the string
+      return formatISODate(date);
     } else {
       return null;
     }
   }
+}
+
+function formatISODate(date) {
+  let month = `${date.getMonth() + 1}`.padStart(2, '0');
+  let day = `${date.getDate()}`.padStart(2, '0');
+  return `${date.getFullYear()}-${month}-${day}`;
 }

--- a/tests/unit/transforms/date-test.js
+++ b/tests/unit/transforms/date-test.js
@@ -12,9 +12,9 @@ module('transform:date', 'Unit | Transform | date', function (hooks) {
     let deserialized = transform.deserialize('2021-12-21');
 
     assert.ok(deserialized instanceof Date);
-    assert.equal(deserialized.getDate(), 21);
-    assert.equal(deserialized.getMonth(), 11);
-    assert.equal(deserialized.getFullYear(), 2021);
+    assert.strictEqual(deserialized.getDate(), 21);
+    assert.strictEqual(deserialized.getMonth(), 11);
+    assert.strictEqual(deserialized.getFullYear(), 2021);
   });
 
   test('it serializes dates to ISO 8601 format without time information', function (assert) {
@@ -25,6 +25,11 @@ module('transform:date', 'Unit | Transform | date', function (hooks) {
     let date = new Date('2020-05-18');
     let serialized = transform.serialize(date);
 
-    assert.equal(serialized, '2020-05-18');
+    assert.strictEqual(serialized, '2020-05-18');
+
+    date = new Date('2022-01-05T00:00:00');
+    serialized = transform.serialize(date);
+
+    assert.strictEqual(serialized, '2022-01-05');
   });
 });


### PR DESCRIPTION
The date transform uses`date.toISOString()` to serialize the date which can result in the wrong day number due to timezone differences.

The datepicker component we use returns dates with hours, minutes and seconds set to 0. If you use this component in a browser in a +1 timezone (or higher) the serialized date will be wrong since the `toISOString()` will return the previous day (with hours set to 23).

Input: `2022-01-05T00:00:00+01:00` -> toISOString(): `2022-01-04T23:00:00Z` -> serialized result: `2022-01-04`

This PR manually formats the date so that it uses the data from the current timezone.