### PR TITLE
Fix an issue with the `warn` util

### DIFF
--- a/addon/transforms/email.js
+++ b/addon/transforms/email.js
@@ -8,7 +8,8 @@ export default class EmailTransform extends Transform {
         return serialized.substring('mailto:'.length);
       } else {
         warn(
-          `Expected email URI but got ${JSON.stringify(serialized)} as value`
+          `Expected email URI but got ${JSON.stringify(serialized)} as value`,
+          { id: 'ember-mu-transform-helpers:email' }
         );
       }
     }

--- a/addon/transforms/phone.js
+++ b/addon/transforms/phone.js
@@ -10,7 +10,8 @@ export default class PhoneTransform extends Transform {
         warn(
           `Expected telephone URI but got ${JSON.stringify(
             serialized
-          )} as value`
+          )} as value`,
+          { id: 'ember-mu-transform-helpers:phone' }
         );
       }
     }

--- a/tests/unit/transforms/date-test.js
+++ b/tests/unit/transforms/date-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('transform:date', 'Unit | Transform | date', function (hooks) {
+module('Unit | Transform | date', function (hooks) {
   setupTest(hooks);
 
   test('it deserializes date strings properly', function (assert) {

--- a/tests/unit/transforms/datetime-test.js
+++ b/tests/unit/transforms/datetime-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('transform:datetime', 'Unit | Transform | datetime', function (hooks) {
+module('Unit | Transform | datetime', function (hooks) {
   setupTest(hooks);
 
   // Replace this with your real tests.

--- a/tests/unit/transforms/datetime-test.js
+++ b/tests/unit/transforms/datetime-test.js
@@ -4,9 +4,23 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Transform | datetime', function (hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
-  test('it exists', function (assert) {
+  test('it deserializes date strings properly', function (assert) {
     let transform = this.owner.lookup('transform:datetime');
-    assert.ok(transform);
+
+    let deserialized = transform.deserialize('2024-07-03');
+
+    assert.ok(deserialized instanceof Date);
+    assert.strictEqual(deserialized.getDate(), 3);
+    assert.strictEqual(deserialized.getMonth(), 7 - 1);
+    assert.strictEqual(deserialized.getFullYear(), 2024);
+  });
+
+  test('it serializes dates to ISO 8601 format', function (assert) {
+    let transform = this.owner.lookup('transform:datetime');
+
+    let date = new Date('2024-07-03');
+    let serialized = transform.serialize(date);
+
+    assert.strictEqual(serialized, '2024-07-03T00:00:00.000Z');
   });
 });

--- a/tests/unit/transforms/email-test.js
+++ b/tests/unit/transforms/email-test.js
@@ -1,12 +1,42 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { getWarnings } from '@ember/test-helpers';
 
 module('Unit | Transform | email', function (hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
-  test('it exists', function (assert) {
+  test('deserialize', function (assert) {
     let transform = this.owner.lookup('transform:email');
-    assert.ok(transform);
+
+    assert.strictEqual(
+      transform.deserialize('mailto:some@email.test'),
+      'some@email.test'
+    );
+    assert.strictEqual(
+      transform.deserialize('some@email.test'),
+      'some@email.test',
+      "strings are returned as-is if they aren't mailto: URIs"
+    );
+    const warnings = getWarnings();
+
+    assert.strictEqual(warnings.length, 1);
+    assert.strictEqual(
+      warnings.at(0).message,
+      'Expected email URI but got "some@email.test" as value',
+      'it displays a warning in the console if it receives a regular string instead of an mailto: URI'
+    );
+  });
+
+  test('serialize', function (assert) {
+    let transform = this.owner.lookup('transform:email');
+
+    assert.strictEqual(
+      transform.serialize('some@email.test'),
+      'mailto:some@email.test'
+    );
+    assert.strictEqual(transform.serialize(123), 'mailto:123');
+    assert.strictEqual(transform.serialize(undefined), null);
+    assert.strictEqual(transform.serialize(null), null);
+    assert.strictEqual(transform.serialize(false), null);
   });
 });

--- a/tests/unit/transforms/language-string-set-test.js
+++ b/tests/unit/transforms/language-string-set-test.js
@@ -1,0 +1,54 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { LangString } from 'ember-mu-transform-helpers/transforms/language-string';
+
+module('Unit | Transform | language string set', function (hooks) {
+  setupTest(hooks);
+
+  test('deserialize', function (assert) {
+    let transform = this.owner.lookup('transform:language-string-set');
+
+    let deserialized = transform.deserialize([
+      { content: 'foo', language: 'nl' },
+      { content: 'bar', language: 'en' },
+    ]);
+    assert.deepEqual(deserialized, [
+      new LangString('foo', 'nl'),
+      new LangString('bar', 'en'),
+    ]);
+    assert.true(
+      deserialized.every((langString) => langString instanceof LangString),
+      'it converts objects to LongString instances'
+    );
+
+    assert.throws(
+      () => {
+        transform.deserialize({ content: 'foo', language: 'nl' });
+      },
+      /Expected array but got object/,
+      'it asserts that the value is an array'
+    );
+  });
+
+  test('serialize', function (assert) {
+    let transform = this.owner.lookup('transform:language-string-set');
+
+    const langStrings = [
+      new LangString('foo', 'nl'),
+      new LangString('bar', 'en'),
+    ];
+    assert.strictEqual(
+      transform.serialize(langStrings),
+      langStrings,
+      'it passes the lang string array as-is'
+    );
+
+    assert.throws(
+      () => {
+        transform.serialize({ content: 'foo', language: 'nl' });
+      },
+      /Expected array but got object/,
+      'it asserts that the value is an array'
+    );
+  });
+});

--- a/tests/unit/transforms/language-string-test.js
+++ b/tests/unit/transforms/language-string-test.js
@@ -1,0 +1,40 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { LangString } from 'ember-mu-transform-helpers/transforms/language-string';
+
+module('Unit | Transform | language string', function (hooks) {
+  setupTest(hooks);
+
+  test('deserialize', function (assert) {
+    let transform = this.owner.lookup('transform:language-string');
+
+    let deserialized = transform.deserialize({
+      content: 'foo',
+      language: 'nl',
+    });
+    assert.true(deserialized instanceof LangString);
+    assert.strictEqual(deserialized.content, 'foo');
+    assert.strictEqual(deserialized.language, 'nl');
+
+    assert.throws(() => {
+      transform.deserialize('foo');
+    }, /Expected object but got string/);
+  });
+
+  test('serialize', function (assert) {
+    let transform = this.owner.lookup('transform:language-string');
+
+    let langString = new LangString('foo', 'nl');
+    let serialized = transform.serialize(langString);
+    assert.true(serialized instanceof LangString);
+    assert.strictEqual(
+      serialized,
+      langString,
+      'it passes the lang string as-is'
+    );
+
+    assert.throws(() => {
+      transform.serialize('foo');
+    }, /Expected object but got string/);
+  });
+});

--- a/tests/unit/transforms/phone-test.js
+++ b/tests/unit/transforms/phone-test.js
@@ -1,12 +1,36 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { getWarnings } from '@ember/test-helpers';
 
 module('Unit | Transform | phone', function (hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
-  test('it exists', function (assert) {
+  test('deserialize', function (assert) {
     let transform = this.owner.lookup('transform:phone');
-    assert.ok(transform);
+
+    assert.strictEqual(transform.deserialize('tel:0123456789'), '0123456789');
+    assert.strictEqual(
+      transform.deserialize('0123456789'),
+      '0123456789',
+      "strings are returned as-is if they aren't tel: URIs"
+    );
+    const warnings = getWarnings();
+
+    assert.strictEqual(warnings.length, 1);
+    assert.strictEqual(
+      warnings.at(0).message,
+      'Expected telephone URI but got "0123456789" as value',
+      'it displays a warning in the console if it receives a regular string instead of a tel: URI'
+    );
+  });
+
+  test('serialize', function (assert) {
+    let transform = this.owner.lookup('transform:phone');
+
+    assert.strictEqual(transform.serialize('0123456789'), 'tel:0123456789');
+    assert.strictEqual(transform.serialize(123), 'tel:123');
+    assert.strictEqual(transform.serialize(undefined), null);
+    assert.strictEqual(transform.serialize(null), null);
+    assert.strictEqual(transform.serialize(false), null);
   });
 });

--- a/tests/unit/transforms/string-set-test.js
+++ b/tests/unit/transforms/string-set-test.js
@@ -1,11 +1,11 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Transform | uri set', function (hooks) {
+module('Unit | Transform | string set', function (hooks) {
   setupTest(hooks);
 
   test('deserialize', function (assert) {
-    let transform = this.owner.lookup('transform:uri-set');
+    let transform = this.owner.lookup('transform:string-set');
 
     let stringSet = ['foo', 'bar'];
     assert.strictEqual(transform.deserialize(stringSet), stringSet);
@@ -27,7 +27,7 @@ module('Unit | Transform | uri set', function (hooks) {
   });
 
   test('serialize', function (assert) {
-    let transform = this.owner.lookup('transform:uri-set');
+    let transform = this.owner.lookup('transform:string-set');
 
     let stringSet = ['foo', 'bar'];
     assert.strictEqual(transform.serialize(stringSet), stringSet);

--- a/tests/unit/transforms/uri-set-test.js
+++ b/tests/unit/transforms/uri-set-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('transform:uri-set', 'Unit | Transform | uri set', function (hooks) {
+module('Unit | Transform | uri set', function (hooks) {
   setupTest(hooks);
 
   // Replace this with your real tests.


### PR DESCRIPTION
Not all transforms had tests, so this adds some basic ones.

It also fixes an issue with the `warn` util, since [it requires an id in Ember v3+](https://deprecations.emberjs.com/id/ember-debug-function-options).

No CI, but tests succeed locally:

![image](https://github.com/mu-semtech/ember-mu-transform-helpers/assets/3533236/6df237d3-3e3b-4fdd-8b6f-4b573fb6ef83)

and the linters don't fail either:
![image](https://github.com/mu-semtech/ember-mu-transform-helpers/assets/3533236/377b3452-9980-45aa-b976-0dddd3c3494e)
