### PR TITLE
Fix the date transform import path

### DIFF
--- a/.woodpecker/.test-pr.yml
+++ b/.woodpecker/.test-pr.yml
@@ -23,5 +23,9 @@ steps:
     image: danlynn/ember-cli:5.8.0-node_20.12
     commands:
       - npm run test:ember
+  test-ember-data-5.3.4:
+    image: danlynn/ember-cli:5.8.0-node_20.12
+    commands:
+      - npx ember try:one ember-data-5.3.4
 when:
   event: pull_request

--- a/addon/transforms/date.js
+++ b/addon/transforms/date.js
@@ -1,6 +1,6 @@
-import { DateTransform as BaseDateTransform } from '@ember-data/serializer/-private';
+import DateTimeTransform from './datetime';
 
-export default class DateTransform extends BaseDateTransform {
+export default class DateTransform extends DateTimeTransform {
   serialize(date) {
     if (date instanceof Date) {
       return formatISODate(date);

--- a/addon/transforms/datetime.js
+++ b/addon/transforms/datetime.js
@@ -1,3 +1,19 @@
-import { DateTransform } from '@ember-data/serializer/-private';
+import {
+  macroCondition,
+  dependencySatisfies,
+  importSync,
+} from '@embroider/macros';
 
-export default DateTransform;
+let DateTimeTransform;
+
+if (macroCondition(dependencySatisfies('ember-data', '^5.3.4'))) {
+  DateTimeTransform = importSync(
+    '@ember-data/serializer/transform'
+  ).DateTransform;
+} else {
+  DateTimeTransform = importSync(
+    '@ember-data/serializer/-private'
+  ).DateTransform;
+}
+
+export default DateTimeTransform;

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -7,6 +7,23 @@ module.exports = async function () {
   return {
     scenarios: [
       {
+        name: 'ember-data-5.3.4',
+        npm: {
+          devDependencies: {
+            'ember-data': '^5.3.4',
+            'ember-inflector': '^4.0.0',
+          },
+          dependencies: {
+            // These are needed for the build to succeed
+            'ember-cli-babel': '^8.2.0',
+            '@babel/core': '^7.12.0',
+          },
+          overrides: {
+            '@ember/test-helpers': '$@ember/test-helpers',
+          },
+        },
+      },
+      {
         name: 'ember-lts-3.24',
         npm: {
           devDependencies: {

--- a/package.json
+++ b/package.json
@@ -31,18 +31,22 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
+    "@embroider/macros": "^1.16.5",
     "ember-cli-babel": "^7.26.10",
     "ember-cli-htmlbars": "^5.7.2"
+  },
+  "peerDependencies": {
+    "ember-data": "^3.12.0 || ^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.6.0",
-    "@embroider/test-setup": "^0.48.1",
+    "@embroider/test-setup": "^4.0.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
-    "ember-auto-import": "^1.12.0",
+    "ember-auto-import": "^2.7.4",
     "ember-cli": "~3.28.6",
     "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-inject-live-reload": "^2.1.0",
@@ -54,12 +58,12 @@
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-page-title": "^6.2.2",
-    "ember-qunit": "^5.1.5",
+    "ember-qunit": "^6.0.0",
     "ember-resolver": "^8.0.3",
     "ember-source": "~3.28.8",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^3.15.0",
-    "ember-try": "^1.4.0",
+    "ember-try": "^3.0.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-ember": "^10.5.8",
@@ -69,9 +73,10 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.5.1",
-    "qunit": "^2.17.2",
-    "qunit-dom": "^1.6.0",
-    "release-it": "^17.4.1"
+    "qunit": "^2.21.0",
+    "qunit-dom": "^3.2.0",
+    "release-it": "^17.4.1",
+    "webpack": "^5.92.1"
   },
   "engines": {
     "node": "12.* || 14.* || >= 16"


### PR DESCRIPTION
The private import path we were using was changed in v5.3.4, but a new public path was added as well. We now conditionally use the correct path based on the available version.

Closes #8 